### PR TITLE
add 'or whitespaces (' ')' to starting comment

### DIFF
--- a/lib/email_parser.rb
+++ b/lib/email_parser.rb
@@ -1,3 +1,4 @@
 # Build a class EmailParser that accepts a string of unformatted 
 # emails. The parse method on the class should separate them into
 # unique email addresses. The delimiters to support are commas (',')
+# or whitespace (' ').


### PR DESCRIPTION
The start-off comment in lib/email_parser.rb did not list whitespace as tested for in the spec and described in the README.
